### PR TITLE
Add Coder workspace image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+docs
+systems/nixos
+systems/darwin
+systems/work
+modules/desktop
+modules/gaming
+README.md

--- a/.github/workflows/coder-workspace-image.yml
+++ b/.github/workflows/coder-workspace-image.yml
@@ -1,0 +1,42 @@
+name: coder-workspace-image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - flake.nix
+      - flake.lock
+      - modules/**
+      - systems/shell/**
+      - coder/Dockerfile
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: coder/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/graytonio/nixos-workspace:latest
+            ghcr.io/graytonio/nixos-workspace:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/coder-workspace-image.yml
+++ b/.github/workflows/coder-workspace-image.yml
@@ -6,9 +6,12 @@ on:
     paths:
       - flake.nix
       - flake.lock
-      - modules/**
+      - modules/base/**
+      - modules/dev/**
+      - modules/apps/**
       - systems/shell/**
       - coder/Dockerfile
+      - .dockerignore
 
 jobs:
   build:

--- a/coder/Dockerfile
+++ b/coder/Dockerfile
@@ -1,0 +1,16 @@
+FROM nixos/nix:latest
+
+RUN mkdir -p /etc/nix && \
+    echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+
+ENV USER=coder
+ENV HOME=/home/coder
+ENV PATH="/home/coder/.nix-profile/bin:${PATH}"
+RUN mkdir -p "$HOME"
+
+WORKDIR /flake
+COPY . .
+
+RUN nix run --impure /flake#homeConfigurations.shell-linux.activationPackage
+
+WORKDIR $HOME

--- a/coder/Dockerfile
+++ b/coder/Dockerfile
@@ -1,4 +1,4 @@
-FROM nixos/nix:latest
+FROM nixos/nix:2.35.2
 
 RUN mkdir -p /etc/nix && \
     echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf


### PR DESCRIPTION
## Summary
- Adds coder/Dockerfile that bakes homeConfigurations.shell-linux into an image via home-manager's activationPackage
- Adds a GitHub Actions workflow that builds and pushes to ghcr.io/graytonio/nixos-workspace on push to main

Part of the homelab Coder remote-dev-environment work — see
graytonio/homelab-flagops-templates docs/superpowers/specs/2026-08-21-nix-coder-workspace-design.md

## Test plan
- [ ] CI build succeeds and pushes the image
- [ ] `docker run --rm -it ghcr.io/graytonio/nixos-workspace:latest fish -c 'go version; kubectl version --client'` shows expected tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)