### PR TITLE
Fix Coder workspace image build: missing nix profile directory

### DIFF
--- a/coder/Dockerfile
+++ b/coder/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /etc/nix && \
 ENV USER=coder
 ENV HOME=/home/coder
 ENV PATH="/home/coder/.nix-profile/bin:${PATH}"
-RUN mkdir -p "$HOME"
+RUN mkdir -p "$HOME" "$HOME/.local/state/nix/profiles"
 
 WORKDIR /flake
 COPY . .


### PR DESCRIPTION
## Summary

The `coder-workspace-image` workflow's build (run https://github.com/graytonio/nixos-config/actions/runs/32437911264, triggered by merging #2) failed on the last step:

```
Starting Home Manager activation
Could not find suitable profile directory, tried /home/coder/.local/state/nix/profiles and /nix/var/nix/profiles/per-user/coder
```

Known Nix/home-manager issue (see nix-community/home-manager#4403) — a fresh Nix installation doesn't have `~/.local/state/nix/profiles/` yet, and home-manager's standalone activation script expects it to already exist rather than creating it. Fix: create it explicitly before running the activation.

## Test plan
- [ ] CI build succeeds this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)