### PR TITLE
Fix Coder workspace image: agent crash-loops without /etc/os-release

### DIFF
--- a/coder/Dockerfile
+++ b/coder/Dockerfile
@@ -8,6 +8,15 @@ ENV HOME=/home/coder
 ENV PATH="/home/coder/.nix-profile/bin:${PATH}"
 RUN mkdir -p "$HOME" "$HOME/.local/state/nix/profiles"
 
+# The Coder agent's host-stats collector (github.com/coder/clistat) requires
+# a valid /etc/*-release file to report workspace CPU/memory stats; the
+# nixos/nix base image doesn't ship one. Without it, the agent's "resources
+# monitor" routine errors out and tears down the entire agent connection
+# (not just the stats display) -- confirmed empirically: the agent
+# authenticated and connected, then immediately disconnected in a loop with
+# "no valid /etc/<distrib>-release file found".
+RUN printf 'NAME="NixOS Container"\nID=nixos\nVERSION_ID="unstable"\nPRETTY_NAME="NixOS Container"\n' > /etc/os-release
+
 WORKDIR /flake
 COPY . .
 


### PR DESCRIPTION
## Summary

Testing the workspace image end-to-end (see graytonio/homelab-flagops-templates#162) found the Coder agent connects, authenticates, then immediately disconnects in a loop:

```
error= error in routine resources monitor: ... failed to create resources fetcher: ... get host info: ... no valid /etc/<distrib>-release file found
```

The agent's host-stats collector (`github.com/coder/clistat`) requires a valid `/etc/*-release` file to report CPU/memory stats. The `nixos/nix` base image doesn't ship one, and when it's missing, the agent doesn't just skip stats collection -- it tears down the whole connection. Fix: write a minimal `/etc/os-release`.

## Test plan
- [ ] CI build succeeds
- [ ] Real workspace creation against the new image reaches "connected" state and stays connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)