### PR TITLE
Set fish as the Coder workspace's default login shell

### DIFF
--- a/coder/Dockerfile
+++ b/coder/Dockerfile
@@ -22,4 +22,16 @@ COPY . .
 
 RUN nix run --impure /flake#homeConfigurations.shell-linux.activationPackage
 
+# home-manager's programs.fish.enable makes fish available and configures it,
+# but standalone home-manager (no full NixOS) can't write /etc/passwd -- that
+# stays whatever the base image shipped (bash) unless set explicitly here.
+# Confirmed empirically: a real workspace's `coder ssh` / web terminal landed
+# in bash even with fish fully installed and configured. awk (not chsh/usermod,
+# which this minimal image may not have) rewrites just the shell field on the
+# root passwd entry.
+RUN FISH_BIN="/home/coder/.nix-profile/bin/fish" && \
+    grep -qxF "$FISH_BIN" /etc/shells 2>/dev/null || echo "$FISH_BIN" >> /etc/shells && \
+    awk -v shell="$FISH_BIN" 'BEGIN{FS=OFS=":"} $1=="root"{$7=shell} {print}' /etc/passwd > /etc/passwd.new && \
+    mv /etc/passwd.new /etc/passwd
+
 WORKDIR $HOME


### PR DESCRIPTION
## Summary

Confirmed on a real workspace: `coder ssh` and the web terminal land in bash, not fish, even though `programs.fish.enable` (modules/base/fish.nix) fully installs and configures it. Standalone home-manager (no full NixOS) can't write `/etc/passwd`, so the login shell stays whatever the base image shipped.

Fix: an `awk` one-liner rewrites root's passwd entry to point at the built fish binary, run after the home-manager activation step (so the binary exists first).

## Test plan
- [ ] CI build succeeds
- [ ] A real workspace's `coder ssh` / web terminal lands in fish

🤖 Generated with [Claude Code](https://claude.com/claude-code)