### PR TITLE
Fix Coder workspace shell fix: awk not available in base image

### DIFF
--- a/coder/Dockerfile
+++ b/coder/Dockerfile
@@ -26,12 +26,21 @@ RUN nix run --impure /flake#homeConfigurations.shell-linux.activationPackage
 # but standalone home-manager (no full NixOS) can't write /etc/passwd -- that
 # stays whatever the base image shipped (bash) unless set explicitly here.
 # Confirmed empirically: a real workspace's `coder ssh` / web terminal landed
-# in bash even with fish fully installed and configured. awk (not chsh/usermod,
-# which this minimal image may not have) rewrites just the shell field on the
-# root passwd entry.
+# in bash even with fish fully installed and configured.
+#
+# Pure POSIX sh + grep only, no awk/sed/chsh/usermod -- confirmed empirically
+# that this minimal nixos/nix base image doesn't have awk (CI failure: "awk:
+# command not found"), so anything beyond the handful of tools already proven
+# present earlier in this Dockerfile (grep, printf, mkdir) can't be assumed
+# available either. ${OLDLINE%:*} is a shell parameter-expansion builtin
+# (strips the shortest trailing ":*" match, i.e. just the final passwd field),
+# not an external command.
 RUN FISH_BIN="/home/coder/.nix-profile/bin/fish" && \
     grep -qxF "$FISH_BIN" /etc/shells 2>/dev/null || echo "$FISH_BIN" >> /etc/shells && \
-    awk -v shell="$FISH_BIN" 'BEGIN{FS=OFS=":"} $1=="root"{$7=shell} {print}' /etc/passwd > /etc/passwd.new && \
+    OLDLINE="$(grep '^root:' /etc/passwd)" && \
+    NEWLINE="${OLDLINE%:*}:${FISH_BIN}" && \
+    grep -v '^root:' /etc/passwd > /etc/passwd.new && \
+    echo "$NEWLINE" >> /etc/passwd.new && \
     mv /etc/passwd.new /etc/passwd
 
 WORKDIR $HOME


### PR DESCRIPTION
## Summary

PR #5's shell fix failed CI: `awk: command not found` -- the minimal `nixos/nix` base image doesn't include it. Rewrote using only `grep` and POSIX shell parameter expansion (no external tool beyond what's already proven present in this Dockerfile). Tested the shell logic locally against a realistic `/etc/passwd` before pushing.

## Test plan
- [ ] CI build succeeds
- [ ] A real workspace's `coder ssh` / web terminal lands in fish

🤖 Generated with [Claude Code](https://claude.com/claude-code)