### PR TITLE
fix(coder): add the POSIX userland the workspace container has no system profile for

### DIFF
--- a/modules/base/default.nix
+++ b/modules/base/default.nix
@@ -4,6 +4,7 @@
     ./starship.nix
     ./tmux.nix
     ./claude-hooks.nix
+    ./posix-tools.nix
     ./nvim
     ./yazi
   ];

--- a/modules/base/posix-tools.nix
+++ b/modules/base/posix-tools.nix
@@ -1,0 +1,41 @@
+# A real NixOS machine gets a baseline POSIX userland from the *system*
+# profile -- nixos/modules/config/system-path.nix installs gnused, gawk,
+# ncurses, diffutils, gnupatch, procps and friends as requiredPackages, so
+# nothing in a user profile ever has to think about them.
+#
+# The Coder workspace container has no NixOS system layer at all: it is the
+# nixos/nix base image plus this standalone home-manager profile, and neither
+# ships that baseline. Confirmed empirically in a live workspace and again
+# against a freshly built ghcr.io/graytonio/nixos-workspace image -- sed, awk,
+# clear, tput, infocmp, diff, cmp, patch, ps, top, pgrep, pkill, free, file,
+# hostname, zip, bzip2 and xz were all absent from both the base image's root
+# profile and the home-manager profile.
+#
+# This is not cosmetic. Config in this very repo shells out to these:
+# modules/base/fish.nix pipes through `sed`, and modules/base/claude-hooks.nix
+# uses `awk`. Both fail silently inside the container without this module.
+# The same gap is why coder/Dockerfile's login-shell fix had to be written in
+# pure POSIX sh -- its first attempt used awk and failed in CI.
+#
+# ncurses earns its place beyond `clear`: without terminfo, `tput` and
+# anything doing terminal capability lookups degrade in the web terminal too.
+#
+# Linux-only on purpose. On NixOS hosts these merely duplicate what the system
+# profile already provides (harmless -- same nixpkgs pin, same derivations),
+# but on Darwin they would replace the BSD userland the OS ships with GNU
+# equivalents on a machine that has nothing wrong with it.
+{ pkgs, lib, ... }: {
+  home.packages = lib.optionals pkgs.stdenv.hostPlatform.isLinux (with pkgs; [
+    gnused
+    gawk
+    ncurses
+    diffutils
+    gnupatch
+    procps
+    file
+    hostname
+    zip
+    bzip2
+    xz
+  ]);
+}


### PR DESCRIPTION
## Problem

Opening a shell in the Coder workspace lands in bash instead of fish, and common utilities like `sed` and `clear` are missing. Two separate causes; **this PR fixes the second one**.

The first is already fixed here — `b9390db` set fish as root's login shell — but `homelab-flagops-templates` pins the workspace image by digest at `sha256:8a90bbb…`, a build from PR #4 that predates it. (PR #5's build failed on the `awk` issue, so the fix only actually shipped in PR #6's build, `sha256:e0e0ca48…`.) That's a one-line digest bump on the other side.

The second cause is not fixed anywhere: `gnused`, `gawk` and `ncurses` are declared nowhere in this flake.

## Root cause

A real NixOS machine gets a baseline POSIX userland from the **system** profile — `nixos/modules/config/system-path.nix` installs gnused, gawk, ncurses, diffutils, gnupatch, procps and friends as `requiredPackages`. The workspace container has no NixOS system layer at all: it is the `nixos/nix` base image plus a standalone home-manager profile, and neither ships that baseline.

Verified against a throwaway pod running the newest image (`sha256:e0e0ca48…`), so this is not an artifact of the stale pin:

```
MISSING: sed awk clear tput infocmp diff cmp patch ps top pgrep pkill free file hostname locale zip bzip2 xz
PRESENT: kill which xargs env date sort uniq cut tr head tail wc od strings man unzip rsync ssh scp jq curl wget git make gcc python3 tar gzip
```

The two package sources, neither carrying them:

| Source | Path | Provides |
|---|---|---|
| nixos/nix base image | `/root/.nix-profile` (176 bins) | bash, grep, less, ls, tee, coreutils |
| home-manager `shell-linux` | `/home/coder/.nix-profile` (190 bins) | fish, git, node, go, kubectl |

## Why it's not cosmetic

Config in this repo shells out to these:

- `modules/base/fish.nix:170` pipes through `sed`
- `modules/base/claude-hooks.nix:9` uses `awk`

Both fail silently inside the container. It is also why `coder/Dockerfile`'s login-shell fix had to be rewritten in pure POSIX sh after the awk version failed CI — the same missing baseline.

`ncurses` earns its place beyond `clear`: without terminfo, `tput` and terminal capability lookups degrade in the web/code-server terminal too.

## Linux-only, on purpose

On NixOS hosts these merely duplicate what the system profile already provides — same nixpkgs pin, same derivations. On Darwin they would replace the BSD userland the OS ships with GNU equivalents on a machine that has nothing wrong with it, so the guard keeps Darwin untouched.

## Verification

Every attribute checked for existence on `x86_64-linux` **and** `aarch64-darwin` before writing the module (this repo has already had one CI failure from assuming a tool was present):

```
gnused gawk ncurses diffutils gnupatch file zip bzip2 xz procps hostname  -> all OK on both
```

Both home configurations evaluate (full eval, no build):

```
shell-linux  -> /nix/store/…-home-manager-generation.drv
shell-darwin -> /nix/store/…-home-manager-generation.drv
```

`shell-linux` now contains all eleven:

```
gnused-4.10 gawk-5.4.1 ncurses-6.6 diffutils-3.12 patch-2.8 procps-4.0.6
file-5.48 hostname-hostname-debian-3.25 zip-3.0 bzip2-1.0.8 xz-5.8.3
```

`shell-darwin` contains none of them, as intended.

## After merge

The `coder-workspace-image` workflow rebuilds on push to `main`; the resulting digest then needs pinning in `homelab-flagops-templates`' `coder-templates/nix-dev/main.tf`, which fixes the fish shell and the missing utilities together in a single workspace restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ4XTeHEyHNd3mwbvLLb7A