### PR TITLE
fix(coder): resolve ncurses/ghostty terminfo collision

### DIFF
--- a/modules/base/posix-tools.nix
+++ b/modules/base/posix-tools.nix
@@ -28,7 +28,24 @@
   home.packages = lib.optionals pkgs.stdenv.hostPlatform.isLinux (with pkgs; [
     gnused
     gawk
-    ncurses
+    # lowPrio because ncurses and Ghostty (modules/apps, pulled in by
+    # shell-linux) both ship share/terminfo/g/ghostty, and home.packages is a
+    # single buildEnv -- an unprioritised collision is a hard build failure:
+    #
+    #   pkgs.buildEnv error: two given paths contain a conflicting subpath:
+    #     .../ncurses-6.6/share/terminfo/g/ghostty  and
+    #     .../ghostty-1.3.1/share/terminfo/g/ghostty
+    #
+    # Priority makes Ghostty win that one file, which is the right outcome --
+    # its own terminfo is authoritative for it. Verified that everything this
+    # package is here for survives the demotion: clear, tput, infocmp, reset
+    # and tic all still resolve to ncurses, as does the general terminfo
+    # database (xterm-256color, screen, vt100).
+    #
+    # Note `nix eval` cannot catch this class of error -- collisions only
+    # surface when the buildEnv is actually realised, which is why it reached
+    # CI. Build home.path, don't just evaluate it, when touching this list.
+    (lib.lowPrio ncurses)
     diffutils
     gnupatch
     procps


### PR DESCRIPTION
Follow-up to #7, which failed to build.

## What broke

`ncurses` and Ghostty (`modules/apps`, pulled in by `shell-linux`) both ship `share/terminfo/g/ghostty`. `home.packages` is a single `buildEnv`, so an unprioritised collision is a hard failure:

```
pkgs.buildEnv error: two given paths contain a conflicting subpath:
  /nix/store/…-ncurses-6.6/share/terminfo/g/ghostty  and
  /nix/store/…-ghostty-1.3.1/share/terminfo/g/ghostty
```

## Fix

`lib.lowPrio ncurses`, so Ghostty wins that one file — the right outcome, since its own terminfo is authoritative for it.

Nothing this package was added for is lost. Verified against the built env:

| | |
|---|---|
| `clear`, `tput`, `infocmp`, `reset`, `tic` | still resolve to `ncurses-6.6` |
| `terminfo/g/ghostty` | now Ghostty's own `xterm-ghostty` |
| general terminfo DB | `xterm-256color`, `screen`, `vt100` all present |

## Why #7 got through review

`nix eval` cannot detect buildEnv collisions — they only surface when the env is actually realised. My pre-merge check evaluated the config and passed, then CI built it and failed.

This one was verified by **building** `home.path` locally, which is the same derivation CI failed on:

```
/nix/store/89v1xq56bbqhrqzyabn5i0yln5cixlsp-home-manager-path
```

and confirming all 18 previously-missing tools are in it:

```
sed awk clear tput infocmp diff cmp patch ps top pgrep pkill free file hostname zip bzip2 xz  -> all OK
fish -> OK
```

A note added to the module tells the next person to build, not evaluate, when touching this list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ4XTeHEyHNd3mwbvLLb7A