### PR TITLE
feat(coder): build the workspace image from a true headless profile

### DIFF
--- a/.github/workflows/coder-workspace-image.yml
+++ b/.github/workflows/coder-workspace-image.yml
@@ -6,10 +6,14 @@ on:
     paths:
       - flake.nix
       - flake.lock
-      - modules/base/**
-      - modules/dev/**
-      - modules/apps/**
-      - systems/shell/**
+      # modules/** rather than enumerating base/dev/apps: modules/profiles.nix
+      # sits at the modules root and the old list would have missed it. A
+      # *missed* rebuild is far worse than a spurious one -- it ships an image
+      # that silently disagrees with the flake -- so over-trigger on purpose.
+      - modules/**
+      # systems/headless/**, not systems/shell/**: the image builds the headless
+      # profile now, so shell-profile changes no longer affect it.
+      - systems/headless/**
       - coder/Dockerfile
       - .dockerignore
 

--- a/coder/Dockerfile
+++ b/coder/Dockerfile
@@ -20,7 +20,17 @@ RUN printf 'NAME="NixOS Container"\nID=nixos\nVERSION_ID="unstable"\nPRETTY_NAME
 WORKDIR /flake
 COPY . .
 
-RUN nix run --impure /flake#homeConfigurations.shell-linux.activationPackage
+# headless-linux, not shell-linux: no GUI applications (Ghostty, Firefox, VS
+# Code) that a container can never display. Measured against this flake's own
+# nixpkgs pin, that takes the profile closure from 8.94 GB to 6.59 GB. It also
+# removes the ncurses/Ghostty terminfo collision documented in
+# modules/base/posix-tools.nix from this image entirely.
+#
+# No --impure needed: systems/headless/home.nix hardcodes username and home
+# directory, where systems/shell/home.nix reads them from $USER/$HOME via
+# builtins.getEnv. The ENV lines above still matter at container runtime, they
+# are just no longer an input to the build.
+RUN nix run /flake#homeConfigurations.headless-linux.activationPackage
 
 # home-manager's programs.fish.enable makes fish available and configures it,
 # but standalone home-manager (no full NixOS) can't write /etc/passwd -- that

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,10 @@
     homeConfigurations."shell-linux"  = mkHome "x86_64-linux"   ./systems/shell/home.nix;
     homeConfigurations."shell-darwin" = mkHome "aarch64-darwin" ./systems/shell/home.nix;
 
+    # Headless: the Coder workspace container. No GUI applications, and no
+    # builtins.getEnv, so coder/Dockerfile activates it without --impure.
+    homeConfigurations."headless-linux" = mkHome "x86_64-linux" ./systems/headless/home.nix;
+
     nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
       specialArgs = { inherit inputs; };
       system = "x86_64-linux";

--- a/modules/base/default.nix
+++ b/modules/base/default.nix
@@ -1,5 +1,6 @@
 { config, pkgs, lib, ... }: {
   imports = [
+    ../profiles.nix
     ./fish.nix
     ./starship.nix
     ./tmux.nix

--- a/modules/dev/default.nix
+++ b/modules/dev/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, system, ... }: {
+{ pkgs, lib, config, system, ... }: {
   imports = [
     ./go.nix
     ./python.nix
@@ -11,7 +11,6 @@
 
   home.packages = with pkgs; [
     just
-    vscode
     docker
     docker-buildx
     docker-compose
@@ -19,5 +18,11 @@
     gnumake
     pscale
     postgresql
+  ] ++ lib.optionals config.profiles.gui.enable [
+    # A GUI editor in an otherwise headless-capable module. Gated rather than
+    # moved to modules/apps because it belongs with the dev toolchain on a
+    # desktop -- it is only unwanted where there is no display, and it is the
+    # single largest package in this profile (2.34 GB closure).
+    vscode
   ];
 }

--- a/modules/profiles.nix
+++ b/modules/profiles.nix
@@ -1,0 +1,21 @@
+# A single switch for "does this machine have a display attached".
+#
+# Defaults to true so every existing profile (shell-linux, shell-darwin, the
+# NixOS and darwin systems) keeps its current package set with no change.
+# systems/headless/home.nix sets it false for the Coder workspace container,
+# which drops GUI applications that a headless container can never display.
+#
+# The GUI *modules* (modules/apps) are excluded simply by not importing them.
+# This option exists for the GUI packages that live inside otherwise-useful
+# modules -- VS Code in modules/dev being the case that prompted it -- where
+# not importing is not an option.
+{ lib, ... }: {
+  options.profiles.gui.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = true;
+    description = ''
+      Whether this machine has a display attached and should install GUI
+      applications. Set false for headless containers and servers.
+    '';
+  };
+}

--- a/systems/headless/home.nix
+++ b/systems/headless/home.nix
@@ -1,0 +1,41 @@
+# Headless profile: the Coder workspace container and anything else that is a
+# shell with no display attached.
+#
+# Differs from systems/shell/home.nix in two ways that matter:
+#
+# 1. It does not import ../../modules/apps (Ghostty, Firefox) and sets
+#    profiles.gui.enable = false, which also drops VS Code from modules/dev.
+#    Those are GUI applications that a container can never display, and they
+#    are not free: measured against the flake's own nixpkgs pin, ghostty is a
+#    1.00 GB closure, firefox 1.52 GB and vscode 2.34 GB, out of an 8.94 GB
+#    shell-linux profile. They also caused a real build failure -- ncurses and
+#    Ghostty both ship share/terminfo/g/ghostty, which is a hard buildEnv
+#    collision (see modules/base/posix-tools.nix). Dropping the GUI removes
+#    that entire class of conflict from the container.
+#
+# 2. It is pure. systems/shell/home.nix reads $USER/$HOME via builtins.getEnv
+#    and therefore requires --impure; the container always runs as the same
+#    user at the same path, so hardcoding them lets coder/Dockerfile activate
+#    this without --impure and makes the build reproducible from the flake
+#    alone.
+{ ... }: {
+  home.username = "coder";
+  home.homeDirectory = "/home/coder";
+
+  nixpkgs.config.allowUnfree = true;
+
+  imports = [
+    ../../modules/base
+    ../../modules/dev
+  ];
+
+  profiles.gui.enable = false;
+
+  # No `nixup` alias here on purpose. The container's profile is baked into
+  # the image by coder/Dockerfile and rebuilt by CI, not switched in place --
+  # an in-workspace `home-manager switch` would write to the PVC and silently
+  # diverge from the image on the next workspace start.
+
+  home.stateVersion = "25.05";
+  programs.home-manager.enable = true;
+}


### PR DESCRIPTION
## Problem

The workspace image activated `shell-linux` — the same profile a desktop uses — so it shipped GUI applications a container can never display.

Measured against this flake's own nixpkgs pin:

| Package | Closure |
|---|---|
| Ghostty | 1.00 GB |
| Firefox | 1.52 GB |
| VS Code | 2.34 GB |

**Profile closure: 8.94 GB → 6.59 GB** (−2.35 GB, 26%). Less than those sum to, because they share dependencies with the rest of the profile.

It also removes a class of build failure. ncurses and Ghostty both ship `share/terminfo/g/ghostty`, a hard `buildEnv` collision — the reason `modules/base/posix-tools.nix` needs `lowPrio` at all. With no Ghostty in the headless profile that conflict cannot arise there. `lowPrio` stays, because `shell-linux` still has both.

## Changes

**`systems/headless/home.nix`** — imports `base` + `dev` only, sets `profiles.gui.enable = false`. Also **pure**: it hardcodes username and home directory where `systems/shell/home.nix` reads `$USER`/`$HOME` via `builtins.getEnv`, so `coder/Dockerfile` drops `--impure`.

**`modules/profiles.nix`** — adds `profiles.gui.enable`, defaulting `true` so every existing profile is untouched. Not importing `modules/apps` handles the GUI *modules*; this option handles GUI *packages inside otherwise-useful modules*, which today means VS Code in `modules/dev`.

**Workflow paths** — now `modules/**` and `systems/headless/**`. The old list enumerated `modules/base|dev|apps` and would have **missed `modules/profiles.nix` entirely**. A missed rebuild ships an image that silently disagrees with the flake, so this deliberately over-triggers.

## What's left in the 6.59 GB

Genuine dev tooling, not bloat — rust 1.6 GB, kotlin + openjdk 1.8 GB, docker + moby 1.7 GB, minikube, nixvim. Trimming further means cutting the toolchain, which is a separate decision.

## Verification

- **Headless builds with `USER` and `HOME` unset** — the `--impure` removal is tested, not assumed.
- **`shell-linux` is content-identical to before**: same file list, same symlink targets, same 8.94 GB closure, `code` still present. Only the store hash moves, because `lib.optionals` reorders `buildEnv`'s `paths` — a different `.drv`, identical output.
- **Headless contents**: `fish sed awk clear node go kubectl git docker nvim` all present; `code firefox ghostty` all absent.
- **No regressions**: `shell-darwin`, `nixosConfigurations.nixos`, `darwinConfigurations.darwin` and `darwinConfigurations.work` all still evaluate.

## After merge

CI rebuilds the image; the resulting digest gets pinned in `homelab-flagops-templates`' `coder-templates/nix-dev/main.tf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ4XTeHEyHNd3mwbvLLb7A