### PR TITLE
fix(coder): expose a stable path to the home-manager activation package

### DIFF
--- a/coder/Dockerfile
+++ b/coder/Dockerfile
@@ -30,7 +30,20 @@ COPY . .
 # directory, where systems/shell/home.nix reads them from $USER/$HOME via
 # builtins.getEnv. The ENV lines above still matter at container runtime, they
 # are just no longer an input to the build.
-RUN nix run /flake#homeConfigurations.headless-linux.activationPackage
+#
+# Built to a stable out-link rather than `nix run` because the path is needed
+# again at *runtime*. The workspace home directory is a PVC that is seeded from
+# this image exactly once, on first boot; it is never re-seeded. So the
+# home-manager dotfile symlinks it captures freeze pointing at whichever
+# home-manager-files store path the seeding image had, and every later image
+# rebuild changes that hash and leaves them dangling -- fish, starship, tmux and
+# nvim all silently lose their config while still starting normally. Confirmed
+# empirically: ~/.config/fish/config.fish pointed at a store path absent from
+# the running image. coder-templates/nix-dev/main.tf re-runs
+# /hm-activation/activate on every workspace start to re-point them (~500ms,
+# idempotent); this out-link is the stable path it looks for.
+RUN nix build --out-link /hm-activation /flake#homeConfigurations.headless-linux.activationPackage \
+    && /hm-activation/activate
 
 # home-manager's programs.fish.enable makes fish available and configures it,
 # but standalone home-manager (no full NixOS) can't write /etc/passwd -- that


### PR DESCRIPTION
## Problem

Opening a shell in the workspace starts fish, but **none of the user's fish config is applied** — no aliases, no starship prompt, no custom functions.

Root cause: the workspace home directory is a PVC seeded from this image **exactly once**, on first boot (`if [ ! -e /mnt/persistent-home/.nix-profile ]`). The home-manager dotfile symlinks it captures freeze pointing at whichever `home-manager-files` store path the seeding image had. Every later image rebuild changes that hash, so the symlinks dangle.

Confirmed in the live workspace:

```
~/.config/fish/config.fish -> /nix/store/5ws33anr…-home-manager-files/.config/fish/config.fish
TARGET MISSING (dangling)
```

`starship.toml`, `tmux.conf` and `.manpath` were all dangling too, as was the HM generation link. The shell still starts, which is why this looked like "fish loads but my config doesn't."

It was latent from the first image rebuild and only became visible once fish became the login shell — under bash the config was never sourced, so nobody noticed.

## Fix

Re-running home-manager's activation at workspace start re-points every symlink at the current image. That needs a deterministic path to the activation package, so this builds it to a stable out-link at `/hm-activation` instead of `nix run`.

Globbing `/nix/store/*-home-manager-generation` also works today (exactly one match) and `coder-templates/nix-dev/main.tf` keeps it as a fallback for images built before this change — but it picks arbitrarily if an image ever carries more than one generation, so it is not what the fix should rely on.

## Verification

Reproduced the failure in an isolated pod — same image, `emptyDir` home seeded like the real PVC, then symlinks rewritten to a nonexistent store path:

```
before: ~/.config/fish/config.fish -> /nix/store/DEADBEEF…-home-manager-files/…   DANGLING
after : ~/.config/fish/config.fish -> /nix/store/4s33zkpp…-home-manager-files/…   EXISTS
```

Post-activation in that pod:

| Check | Result |
|---|---|
| `config.fish` | 58 lines, 13 aliases, `starship init` |
| fish functions | `clone.fish`, `envsource.fish`, `gac.fish`, `ping_alert.fish`, … |
| interactive fish | prompt defined, `STARSHIP_SHELL` set |
| `starship.toml`, `tmux.conf`, `.manpath` | all resolve |
| `PATH` / `~/.nix-profile` | unchanged; `fish sed awk node go kubectl git nvim starship` all resolve |
| second activation | clean, dotfiles still correct (idempotent) |
| duration | 498 ms |

Also verified here that `nix build --out-link` produces a working link and `/hm-activation/activate` is executable.

## Companion change

`coder-templates/nix-dev/main.tf` in `homelab-flagops-templates` runs `/hm-activation/activate` at workspace start, before sourcing `hm-session-vars.sh` and starting the Coder agent, and is explicitly never allowed to abort that chain — if activation fails the agent must still come up, or the workspace is unreachable and undebuggable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ4XTeHEyHNd3mwbvLLb7A